### PR TITLE
Fix write typespec to handle lists of strings

### DIFF
--- a/lib/mudbrick/text_block.ex
+++ b/lib/mudbrick/text_block.ex
@@ -27,11 +27,11 @@ defmodule Mudbrick.TextBlock do
   @type part_options :: [part_option()]
 
   @type write_tuple :: {String.t(), part_options()}
+  @type write_part :: String.t() | write_tuple()
 
   @type write ::
-          String.t()
-          | write_tuple()
-          | list(write_tuple())
+          write_part()
+          | list(write_part())
 
   @type t :: %__MODULE__{
           align: alignment(),


### PR DESCRIPTION
I found that the following code would give me a dialyzer error that my function would never return.

``` elixir
    Mudbrick.new(compress: true, fonts: %{bodoni: Extra.Font.bodoni_regular()})
    |> Mudbrick.page(size: Mudbrick.Page.size(:a4))
    |> Mudbrick.text(
      [
        "Name: ",
        "Stuff:\n"
      ],
      auto_kern: true,
      font: :bodoni,
      font_size: 12,
      leading: 18,
      position: {26, height - 48}
    )
    |> Mudbrick.render()
```